### PR TITLE
feat: handle zero row returns for pages robustly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/*target
 .vscode
+/.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,163 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "rust-flake-parts",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1710886643,
+        "narHash": "sha256-saTZuv9YeZ9COHPuj8oedGdUwJZcbQ3vyRqe7NVJMsQ=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "5bace74e9a65165c918205cf67ad3977fe79c584",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "ref": "v0.16.3",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "rust-flake-parts",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1711520562,
+        "narHash": "sha256-rVE+5nzGarXDYoXPcySg+/NpkPZu53H3YhtE1nElUhg=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "21cf09a640b2a0b8f805aa767f42916c9579776b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1714641030,
+        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1701282334,
+        "narHash": "sha256-MxCVrXY6v4QmfTwIysjjaX0XUhqBbxTWWB4HXtDYsdk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "057f9aecfb71c4437d2b27d3323df7f93c010b7e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1714640452,
+        "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+      }
+    },
+    "parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "rust-flake-parts",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-flake-parts": "rust-flake-parts"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1711443624,
+        "narHash": "sha256-K5aLPjCF3A9ArczT5X/CKo1bfQEwGK5CsJ3eYHIjEnk=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "4b33850c39049047e2deb4269b60bd8330b68031",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-flake-parts": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "parts": "parts"
+      },
+      "locked": {
+        "lastModified": 1714530829,
+        "narHash": "sha256-EMe51HTiuqM2InNxhMftC3chWmUJEgwTatCo7wkawtM=",
+        "owner": "talo",
+        "repo": "rust-flake-parts",
+        "rev": "6cf02a55d3502881428d4329de80c80403b98adf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "talo",
+        "repo": "rust-flake-parts",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "lsor lightweight orm for rust";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/23.11";
+    rust-flake-parts.url = "github:talo/rust-flake-parts";
+    rust-flake-parts.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = inputs@{ flake-parts, rust-flake-parts, ... }:
+    let version = "0.1.0";
+    in flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [ rust-flake-parts.flakeModule ];
+      systems = [ "x86_64-linux" "aarch64-darwin" ];
+      perSystem = { config, self', inputs', pkgs, system, ... }: {
+        commonCraneArgs = {
+          src = ./.;
+          buildInputs = [ pkgs.cargo-sort pkgs.cargo-sweep ];
+        };
+        craneProjects.lsor = { inherit version; };
+      };
+    };
+}

--- a/lsor-core/src/exec.rs
+++ b/lsor-core/src/exec.rs
@@ -88,15 +88,24 @@ where
 
     let mut driver = Driver::new();
     select_page_info(subquery, cursor, start.clone(), end.clone()).push_to_driver(&mut driver);
-    let row = driver.fetch_one(executor).await?;
+    let row = driver.fetch_optional(executor).await?;
     let page_info = PageInfo {
-        has_next_page: row.try_get("has_next_page")?,
-        has_previous_page: row.try_get("has_prev_page")?,
+        has_next_page: row
+            .as_ref()
+            .map(|x| x.try_get("has_next_page"))
+            .unwrap_or(Ok(false))?,
+        has_previous_page: row
+            .as_ref()
+            .map(|x| x.try_get("has_prev_page"))
+            .unwrap_or(Ok(false))?,
         start_cursor: Some(start),
         end_cursor: Some(end),
     };
     let total_count = TotalCount {
-        total_count: row.try_get("total_count")?,
+        total_count: row
+            .as_ref()
+            .map(|x| x.try_get("total_count"))
+            .unwrap_or(Ok(0))?,
     };
 
     let mut conn = Connection::with_additional_fields(

--- a/lsor-core/tests/lib.rs
+++ b/lsor-core/tests/lib.rs
@@ -72,8 +72,8 @@ impl Sorting for MetadataSort {
 impl Row for Metadata {
     fn column_names() -> impl Iterator<Item = (ColumnName, IsPk)> {
         (Some((col(stringify!(name)), false)).into_iter())
-            .chain(Some((col(stringify!(description)), false)).into_iter())
-            .chain(Some((col(stringify!(tags)), false)).into_iter())
+            .chain(Some((col(stringify!(description)), false)))
+            .chain(Some((col(stringify!(tags)), false)))
     }
 
     fn push_column_values(&self, driver: &mut Driver) {
@@ -145,10 +145,10 @@ pub struct AccountFilter {
 impl Row for Account {
     fn column_names() -> impl Iterator<Item = (ColumnName, IsPk)> {
         (Some((col(stringify!(id)), true)).into_iter())
-            .chain(Some((col(stringify!(created_at)), false)).into_iter())
-            .chain(Some((col(stringify!(updated_at)), false)).into_iter())
-            .chain(Some((col(stringify!(deleted_at)), false)).into_iter())
-            .chain(Some((col(stringify!(tier)), false)).into_iter())
+            .chain(Some((col(stringify!(created_at)), false)))
+            .chain(Some((col(stringify!(updated_at)), false)))
+            .chain(Some((col(stringify!(deleted_at)), false)))
+            .chain(Some((col(stringify!(tier)), false)))
             .chain(Metadata::column_names())
     }
 


### PR DESCRIPTION
Currently, we see failures when pages have 0 rows in some cases.

This PR addresses the case by making the fetch optional. It would be slightly better to fix it at the sql level, but this approach is a faster fix