### PR TITLE
Basic Fifo cache

### DIFF
--- a/lsor-core/src/cache.rs
+++ b/lsor-core/src/cache.rs
@@ -3,7 +3,6 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-// use tokio::sync::Mutex;
 
 pub trait Cache {
     fn get(&self, key: &str) -> Option<String>;

--- a/lsor-core/src/cache.rs
+++ b/lsor-core/src/cache.rs
@@ -1,0 +1,90 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    rc::Rc,
+    sync::RwLock,
+};
+
+pub trait Cache {
+    fn get(&self, key: &str) -> Option<String>;
+    fn insert(&self, key: String, value: String);
+}
+
+#[derive(Clone, Debug)]
+pub struct FifoCache {
+    cache: Rc<RwLock<HashMap<String, String>>>,
+    cache_fifo: Rc<RwLock<VecDeque<String>>>,
+    cache_limit_n: usize,
+}
+
+impl FifoCache {
+    pub fn new(cache_limit_n: usize) -> Self {
+        Self {
+            cache: Rc::new(RwLock::new(HashMap::new())),
+            cache_fifo: Rc::new(RwLock::new(VecDeque::new())),
+            cache_limit_n,
+        }
+    }
+}
+
+impl Cache for FifoCache {
+    fn get(&self, key: &str) -> Option<String> {
+        let cache = self.cache.read().unwrap();
+        cache.get(key).cloned()
+    }
+
+    fn insert(&self, key: String, value: String) {
+        let mut cache = self.cache.write().unwrap();
+        let mut cache_fifo = self.cache_fifo.write().unwrap();
+
+        if cache_fifo.len() >= self.cache_limit_n {
+            if let Some(key) = cache_fifo.pop_front() {
+                cache.remove(&key);
+            }
+        }
+
+        cache.insert(key.clone(), value);
+
+        cache_fifo.retain(|k| k != &key);
+        cache_fifo.push_back(key);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::time::Instant;
+
+    use crate::{col, from, gt, table, Driver, PushPrql as _};
+
+    use super::*;
+
+    #[test]
+    fn test_fifo_cache() {
+        let cache = FifoCache::new(10);
+
+        let mut driver = Driver::with_cache(Box::new(cache.clone()));
+        {
+            from(table("users"))
+                .filter(gt(col("age"), 18))
+                .push_to_driver(&mut driver);
+        }
+        let begin = Instant::now();
+        assert_eq!(driver.sql(), "SELECT * FROM users WHERE age > $1");
+        let end = Instant::now();
+        let duration = end.duration_since(begin);
+        println!("duration: {:?}", duration);
+
+        let mut driver = Driver::with_cache(Box::new(cache.clone()));
+        {
+            from(table("users"))
+                .filter(gt(col("age"), 18))
+                .push_to_driver(&mut driver);
+        }
+        let begin = Instant::now();
+        assert_eq!(driver.sql(), "SELECT * FROM users WHERE age > $1");
+        let end = Instant::now();
+        let cached_duration = end.duration_since(begin);
+
+        assert!(cached_duration < duration);
+        println!("cached_duration: {:?}", cached_duration);
+    }
+}

--- a/lsor-core/src/cache.rs
+++ b/lsor-core/src/cache.rs
@@ -1,26 +1,27 @@
 use std::{
     collections::{HashMap, VecDeque},
-    rc::Rc,
-    sync::RwLock,
+    sync::{Arc, RwLock},
 };
+
+// use tokio::sync::Mutex;
 
 pub trait Cache {
     fn get(&self, key: &str) -> Option<String>;
     fn insert(&self, key: String, value: String);
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct FifoCache {
-    cache: Rc<RwLock<HashMap<String, String>>>,
-    cache_fifo: Rc<RwLock<VecDeque<String>>>,
+    cache: Arc<RwLock<HashMap<String, String>>>,
+    cache_fifo: Arc<RwLock<VecDeque<String>>>,
     cache_limit_n: usize,
 }
 
 impl FifoCache {
     pub fn new(cache_limit_n: usize) -> Self {
         Self {
-            cache: Rc::new(RwLock::new(HashMap::new())),
-            cache_fifo: Rc::new(RwLock::new(VecDeque::new())),
+            cache: Arc::new(RwLock::new(HashMap::new())),
+            cache_fifo: Arc::new(RwLock::new(VecDeque::new())),
             cache_limit_n,
         }
     }
@@ -28,7 +29,7 @@ impl FifoCache {
 
 impl Cache for FifoCache {
     fn get(&self, key: &str) -> Option<String> {
-        let cache = self.cache.read().unwrap();
+        let cache = self.cache.read().unwrap(); //.iread().unwrap();
         cache.get(key).cloned()
     }
 

--- a/lsor-core/src/driver.rs
+++ b/lsor-core/src/driver.rs
@@ -9,7 +9,7 @@ use crate::Cache;
 pub struct Driver {
     prql: String,
     arguments: PgArguments,
-    cache: Option<Box<dyn Cache>>,
+    cache: Option<Box<dyn Cache + Send + Sync + 'static>>,
 }
 
 impl Driver {
@@ -21,11 +21,11 @@ impl Driver {
         }
     }
 
-    pub fn with_cache(cache: Box<dyn Cache>) -> Self {
+    pub fn with_cache(cache: Box<dyn Cache + Send + Sync +'static>) -> Self {
         Driver {
             prql: String::new(),
             arguments: PgArguments::default(),
-            cache: Some(cache.into()),
+            cache: Some(cache),
         }
     }
 
@@ -138,7 +138,7 @@ impl Driver {
         }
     }
 
-    fn fetch_from_cache(&self, key: &String) -> Option<String> {
+    fn fetch_from_cache(&self, key: &str) -> Option<String> {
         self.cache.as_ref().and_then(|cache| cache.get(key))
     }
 }

--- a/lsor-core/src/lib.rs
+++ b/lsor-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod aggregate;
+pub mod cache;
 pub mod column;
 pub mod cond;
 pub mod cursor;
@@ -17,6 +18,7 @@ pub mod take;
 pub mod var;
 
 pub use aggregate::*;
+pub use cache::*;
 pub use column::*;
 pub use cond::*;
 pub use cursor::*;


### PR DESCRIPTION
This PR implements a very basic FIFO cache that uses the PRQL as the cache key, and the compiled SQL as the final value.