### PR TITLE
feat: pass driver and cache, and make cache arc

### DIFF
--- a/lsor-core/src/cache.rs
+++ b/lsor-core/src/cache.rs
@@ -1,26 +1,27 @@
 use std::{
     collections::{HashMap, VecDeque},
-    rc::Rc,
-    sync::RwLock,
+    sync::{Arc, RwLock},
 };
+
+// use tokio::sync::Mutex;
 
 pub trait Cache {
     fn get(&self, key: &str) -> Option<String>;
     fn insert(&self, key: String, value: String);
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct FifoCache {
-    cache: Rc<RwLock<HashMap<String, String>>>,
-    cache_fifo: Rc<RwLock<VecDeque<String>>>,
+    cache: Arc<RwLock<HashMap<String, String>>>,
+    cache_fifo: Arc<RwLock<VecDeque<String>>>,
     cache_limit_n: usize,
 }
 
 impl FifoCache {
     pub fn new(cache_limit_n: usize) -> Self {
         Self {
-            cache: Rc::new(RwLock::new(HashMap::new())),
-            cache_fifo: Rc::new(RwLock::new(VecDeque::new())),
+            cache: Arc::new(RwLock::new(HashMap::new())),
+            cache_fifo: Arc::new(RwLock::new(VecDeque::new())),
             cache_limit_n,
         }
     }
@@ -28,7 +29,7 @@ impl FifoCache {
 
 impl Cache for FifoCache {
     fn get(&self, key: &str) -> Option<String> {
-        let cache = self.cache.read().unwrap();
+        let cache = self.cache.read().unwrap(); //.iread().unwrap();
         cache.get(key).cloned()
     }
 

--- a/lsor-core/src/driver.rs
+++ b/lsor-core/src/driver.rs
@@ -9,7 +9,7 @@ use crate::Cache;
 pub struct Driver {
     prql: String,
     arguments: PgArguments,
-    cache: Option<Box<dyn Cache>>,
+    cache: Option<Box<dyn Cache + Send + Sync + 'static>>,
 }
 
 impl Driver {
@@ -21,11 +21,11 @@ impl Driver {
         }
     }
 
-    pub fn with_cache(cache: Box<dyn Cache>) -> Self {
+    pub fn with_cache(cache: Box<dyn Cache + Send + Sync +'static>) -> Self {
         Driver {
             prql: String::new(),
             arguments: PgArguments::default(),
-            cache: Some(cache.into()),
+            cache: Some(cache),
         }
     }
 
@@ -138,7 +138,7 @@ impl Driver {
         }
     }
 
-    fn fetch_from_cache(&self, key: &String) -> Option<String> {
+    fn fetch_from_cache(&self, key: &str) -> Option<String> {
         self.cache.as_ref().and_then(|cache| cache.get(key))
     }
 }


### PR DESCRIPTION
This PR makes using a cached driver possible by making it an argument in the load_* functions.

It also makes the cache threadsafe by Arc'ing and constraining trait bounds