### PR TITLE
fix: Handle null values in columns for Json types

### DIFF
--- a/lsor-proc-macro/src/row.rs
+++ b/lsor-proc-macro/src/row.rs
@@ -38,6 +38,8 @@ pub fn expand_derive_row(input: TokenStream) -> TokenStream {
         let flat = util::has_flatten_attr(&field.attrs);
         if flat {
             quote! { #field_ident: <_>::from_row(row)?, }
+        } else if json && util::is_option_type(&field.ty) {
+            quote! { #field_ident: row.try_get::<Option<::sqlx::types::Json<_>>, _>(stringify!(#field_ident))?.map(|x| x.0), }
         } else if json {
             quote! { #field_ident: row.try_get::<::sqlx::types::Json<_>, _>(stringify!(#field_ident))?.0, }
             // quote! { #field_ident: row.try_get(stringify!(#field_ident))?, }

--- a/lsor-proc-macro/src/util.rs
+++ b/lsor-proc-macro/src/util.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenTree};
-use syn::{Attribute, Ident};
+use syn::{Attribute, Ident, Type};
 
 pub(crate) fn concat_idents(ident1: &Ident, ident2: &Ident) -> Ident {
     let combined = format!("{}{}", ident1, ident2);
@@ -136,6 +136,17 @@ pub(crate) fn has_skip_sort_attr(attrs: &[Attribute]) -> bool {
 
 pub(crate) fn has_json_attr(attrs: &[Attribute]) -> bool {
     has_any_attr(&["json"], attrs)
+}
+
+pub(crate) fn is_option_type(field_ty: &Type) -> bool {
+    if let Type::Path(type_path) = field_ty {
+        if type_path.path.segments.len() == 1 {
+            if let Some(seg) = type_path.path.segments.first() {
+                return seg.ident.to_string() == "Option";
+            }
+        }
+    }
+    false
 }
 
 fn has_any_attr(options: &[&str], attrs: &[Attribute]) -> bool {


### PR DESCRIPTION
When a field type is defined as Option<...> and the json attribute is given, handle the case where the DB column is nullabe and null values are returned from a query.